### PR TITLE
Fix GitHub Actions:

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - uses: manusa/actions-setup-minikube@v2.6.0
+      - uses: manusa/actions-setup-minikube@v2.7.0
         with:
-          minikube version: "v1.25.2"
-          kubernetes version: "v1.24.1"
+          minikube version: "v1.26.1"
+          kubernetes version: "v1.24.3"
           github token: ${{secrets.GITHUB_TOKEN}}
       - run: pip install pyyaml
       - run: curl https://skupper.io/install.sh | sh


### PR DESCRIPTION
Closes #7 

## Changes
- Update manusa/actions-setup-minikube from 2.6.0 to v2.7.0
- Hence, updated minikube version: v1.26.1
- And updated kubernetes version: v1.24.3